### PR TITLE
don't use deprecated is_status_class method

### DIFF
--- a/lib/MojoX/JSON/RPC/Client.pm
+++ b/lib/MojoX/JSON/RPC/Client.pm
@@ -108,7 +108,7 @@ sub _process_result {
     }
 
     # Check if RPC call is succesfull
-    if ( !( $tx_res->is_status_class(200) || $tx_res->is_status_class(400) ) )
+    if ( !( $tx_res->is_success() || $tx_res->is_client_error() ) )
     {
         return;
     }


### PR DESCRIPTION
If using the client with the current mojolicious version it reports a deprecation on every request.

```
Mojo::Message::Response::is_status_class is DEPRECATED in favor of new is_* methods at C:/Strawberry/perl/site/lib/MojoX/JSON/RPC/Client.pm line 111.
```